### PR TITLE
Fixed some overlap issues in mobile view.

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,26 +29,26 @@
        <li class="library">
          <div class="circle">
            <a class="text secondary library-name" href="https://github.com/elixir-circuits/circuits_gpio"><i class="far fa-lightbulb"></i></a>
-           <h3><a href="https://github.com/elixir-circuits/circuits_gpio">GPIO</a></h3>
          </div>
+         <h3><a href="https://github.com/elixir-circuits/circuits_gpio">GPIO</a></h3>
        </li>
        <li class="library">
          <div class="circle">
            <a class="text secondary library-name" href="https://github.com/elixir-circuits/circuits_i2c"><i class="fas fa-microchip"></i></a>
-           <h3><a href="https://github.com/elixir-circuits/circuits_i2c">I2C</a></h3>
          </div>
+         <h3><a href="https://github.com/elixir-circuits/circuits_i2c">I2C</a></h3>
        </li>
        <li class="library">
          <div class="circle">
            <a class="text secondary library-name" href="https://github.com/elixir-circuits/circuits_spi"><i class="fas fa-sd-card"></i></a>
-           <h3><a href="https://github.com/elixir-circuits/circuits_spi">SPI</a></h3>
          </div>
+         <h3><a href="https://github.com/elixir-circuits/circuits_spi">SPI</a></h3>
         </li>
         <li class="library">
           <div class="circle">
             <a class="text secondary library-name" href="https://github.com/elixir-circuits/circuits_uart"><i class="fas fa-stream"></i></a>
-            <h3><a href="https://github.com/elixir-circuits/circuits_uart">UART</a></h3>
           </div>
+          <h3><a href="https://github.com/elixir-circuits/circuits_uart">UART</a></h3>
         </li>
      </ul>
     </div>

--- a/styles.css
+++ b/styles.css
@@ -142,7 +142,6 @@ ul {
 }
 
 .library {
-  height: 150px;
   width: 100%;
   margin-top: 25px;
 }
@@ -153,6 +152,7 @@ ul {
 
 .library .library-name {
   font-size: 3.5rem;
+  line-height: 150px;
 }
 
 .library a {
@@ -160,14 +160,13 @@ ul {
 }
 
 .library h3 {
-  line-height: 0;
+  text-align: center;
   margin-top: 15px;
   font-size: 2rem;
 }
 
 .library .circle {
   text-align: center;
-  line-height: 150px;
 }
 
 .library-search {


### PR DESCRIPTION
Saw this:

![site-before](https://user-images.githubusercontent.com/1971237/52008727-8afb4a80-24d1-11e9-9d17-99fd160d0f81.png)

Should be this I think:
![site-after](https://user-images.githubusercontent.com/1971237/52008747-964e7600-24d1-11e9-9012-e5b4ef600bfe.png)
