### PR TITLE
Make tables use all available space

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -203,6 +203,7 @@ ul {
     border-collapse: collapse;
     border-spacing: 0;
     font: normal 13px Roboto, sans-serif;
+    width: 100%;
 }
 .search-table thead th {
     background-color: #101010;


### PR DESCRIPTION
This is a minor enhancement. Currently table widths depend on the max text length, which can lead to tables in different widths especially when the display is large. Just by specifying the 100% width, we can make them look consistent.

```css
.search-table {
  width: 100%;
}
```
![Elixir Circuits website table width Screen Recording 2021-08-29 at 11 56 39 AM](https://user-images.githubusercontent.com/7563926/131257109-2bc3723a-a8bd-45a7-93b4-fd95e013fdac.gif)

I think alternatively we could set `max-width` to a certain value.

```css
.search-table {
    max-width: 75rem;
}
```
![max-width Screen Recording 2021-08-29 at 12 11 42 PM](https://user-images.githubusercontent.com/7563926/131257388-73e86962-c273-4492-a78c-cf3a137b83fc.gif)
